### PR TITLE
Allow app_name to be specified

### DIFF
--- a/lib/logplex/publisher.rb
+++ b/lib/logplex/publisher.rb
@@ -19,7 +19,7 @@ module Logplex
       unless messages.is_a? Array
         message_list = [message_list]
       end
-      message_list.map! { |m| Message.new(m, opts.merge(app_name: @token)) }
+      message_list.map! { |m| Message.new(m, { app_name: @token }.merge(opts)) }
       message_list.each(&:validate)
       if message_list.inject(true) { |accum, m| m.valid? }
         begin

--- a/spec/logplex/publisher_spec.rb
+++ b/spec/logplex/publisher_spec.rb
@@ -29,13 +29,24 @@ describe Logplex::Publisher do
       end
 
       it 'sends many messages in one request when passed an array' do
-        Excon.stub({ method: :post, password: "t.some-token", body: /here is another/ }, status: 204)
-        expect(Excon).to receive(:post).once
+        Excon.stub({ method: :post, password: "t.some-token", body: /message for you.+here is another.+some final thoughts/ }, status: 204)
         messages = ['I have a message for you', 'here is another', 'some final thoughts']
-
         publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
-
         publisher.publish(messages)
+      end
+
+      it 'uses the token if app_name is not given' do
+        Excon.stub({ method: :post, password: "t.some-token", body: /t.some-token/ }, status: 204)
+        message = 'I have a message for you'
+        publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
+        publisher.publish(message)
+      end
+
+      it 'uses the given app_name' do
+        Excon.stub({ method: :post, password: "t.some-token", body: /foo/ }, status: 204)
+        message = 'I have a message for you'
+        publisher = Logplex::Publisher.new('https://token:t.some-token@logplex.example.com')
+        publisher.publish(message, app_name: 'foo')
       end
 
       it 'does the thing' do


### PR DESCRIPTION
This allows producers for direct drains (not via logplex/logfwd infrastructure) to specify the app_name. If the app_name is not passed the previous behavior of using the token will be used.