### PR TITLE
Add support for Bearer authentication.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 .tags
+.idea

--- a/lib/logplex/publisher.rb
+++ b/lib/logplex/publisher.rb
@@ -9,9 +9,10 @@ module Logplex
                       Excon::Errors::Unauthorized,
                       Timeout::Error].freeze
 
-    def initialize(logplex_url = nil)
+    def initialize(logplex_url = nil, bearer_token: nil)
       @logplex_url = logplex_url || Logplex.configuration.logplex_url
       @token = URI(@logplex_url).password || Logplex.configuration.app_name
+      @auth_headers = bearer_token ? { 'Authorization' => "Bearer #{bearer_token}" } : {}
     end
 
     def publish(messages, opts={})
@@ -36,11 +37,11 @@ module Logplex
     private
 
     def api_post(message, number_messages)
-      Excon.post(@logplex_url, body: message, headers: {
+      Excon.post(@logplex_url, body: message, headers: @auth_headers.merge({
         "Content-Type" => 'application/logplex-1',
         "Content-Length" => message.length,
         "Logplex-Msg-Count" => number_messages
-      }, expects: [200, 202, 204])
+      }), expects: [200, 202, 204])
     end
   end
 end

--- a/lib/logplex/version.rb
+++ b/lib/logplex/version.rb
@@ -1,3 +1,3 @@
 module Logplex
-  VERSION = "0.0.6".freeze
+  VERSION = "0.0.7".freeze
 end

--- a/spec/logplex/publisher_spec.rb
+++ b/spec/logplex/publisher_spec.rb
@@ -102,5 +102,17 @@ describe Logplex::Publisher do
       expect(Excon).to receive(:post).with(any_args, hash_including(:headers => headers))
       Logplex::Publisher.new('https://token:t.some-token@logplex.example.com').publish(message)
     end
+
+    it "supports bearer authentication" do
+      message = 'hello-bearer'
+      headers = {
+        "Authorization" => 'Bearer test-bearer-token',
+        "Content-Type" => 'application/logplex-1',
+        "Content-Length" => 70,
+        "Logplex-Msg-Count" => 1
+      }
+      expect(Excon).to receive(:post).with(any_args, hash_including(:headers => headers))
+      Logplex::Publisher.new('https://logplex-next.example.com', bearer_token: 'test-bearer-token').publish(message)
+    end
   end
 end


### PR DESCRIPTION
Fir-generation logplex endpoints require Bearer authentication with JWT tokens that identify the underlying submitting service.